### PR TITLE
Print out version when logging is set to "cli"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ RapidAPI Testing Worker is available as a package on NPM. You can install RapidA
 #### Install from the command line
 
 ```
-npm install -g @rapidapi/testing-worker@0.0.11
+npm install -g @rapidapi/testing-worker
 ```
 
 #### Install via package.json
 
 ```json
-"@rapidapi/testing-worker": "0.0.11"
+"@rapidapi/testing-worker": "^0.0.11"
 ```
 
 ## Running Workers with Examples
@@ -72,4 +72,24 @@ Below command will run a RapidAPI Testing Worker that fetches 200 new tests ever
 
 ```
 testing-worker -s 3866fd2aaeb474a76fdf236062660fb31df234b8 -k custom_worker -c 1234567 --frequency 5000 --batch 200
+```
+
+## Envirnment variables.
+
+Alternately, you can start the worker with preset env vars and omit the command options entirely.
+
+**The following env vars are supported:**
+
+- `BASE_URL`
+- `LOCATION_KEY`
+- `LOCATION_SECRET`
+- `LOCATION_CONTEXT`
+- `FREQUENCY`
+- `POLLING_TIME_MAX`
+- `BATCH_SIZE`
+
+Once loaded, you can start the work without the command options:
+
+```
+testing-worker
 ```

--- a/src/main.js
+++ b/src/main.js
@@ -68,7 +68,7 @@ async function execute(logLevel = "on") {
   const logging = cmd.logging === "on" || cmd.logging === "cli";
 
   if (cmd.logging === "cli") {
-    consola.info("Starting a the worker from the CLI with the following settings:\n");
+    consola.info(`Starting a the worker version: ${pjson.version} from the CLI with the following settings:\n`);
     consola.info(`RapidAPI Testing base URL <url>: ${cmd.url}`);
     consola.info(`RapidAPI Testing location secret <secret>: ${cmd.secret.substr(0, 3)}********`);
     consola.info(`RapidAPI Testing location key <key>: ${cmd.key}`);


### PR DESCRIPTION
Add version in logging output. This is helpful to enusre that the aws lambda's have indeed been updated from previous code.