### PR TITLE
Docker needs to run on node14

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -1,5 +1,5 @@
 # Define custom function directory
-FROM node:12-buster as basebuild
+FROM node:14-buster as basebuild
 
 WORKDIR "/worker"
 
@@ -7,4 +7,4 @@ COPY . .
 
 RUN yarn install --frozen-lockfile
 
-CMD ["node", "src/cli.js"]
+CMD ["node", "src/main.js"]


### PR DESCRIPTION
Due to null chain operators, we need to upgrade node
The main function is main.js not cli.js anymore.

- Docker images not uploading to the docker hub at present. I suspect the auth key/token is incorrect.
- I'm also unable to launch a docker container locally and get it to handle test executions, so I'll continue to work on that, but I have low confidence about uploading images unless they can be tested in some capacity
