### PR TITLE
Add step (http) timeout

### DIFF
--- a/src/RapidTest.js
+++ b/src/RapidTest.js
@@ -13,7 +13,11 @@ async function executeTest(testExecution, locationDetails) {
       ...testExecution.envVariables,
     });
     try {
-      testResult = await executable.eval(context, testExecution.test.timeoutSeconds);
+      testResult = await executable.eval(
+        context,
+        testExecution.test.timeoutSeconds,
+        testExecution.test.stepTimeoutSeconds
+      );
     } catch (e) {
       consola.warn("Failed to execute test");
       consola.warn(e);

--- a/src/models/TestExecutable.js
+++ b/src/models/TestExecutable.js
@@ -52,7 +52,7 @@ class TestExecutable {
     this.actions = actions;
   }
 
-  async eval(context, timeoutSeconds = 300) {
+  async eval(context, timeoutSeconds = 300, stepTimeoutSeconds = 15) {
     //todo recursion
     var cancelled = false;
 
@@ -76,13 +76,14 @@ class TestExecutable {
         if (cancelled) {
           break;
         }
-        //1. materealize parameters -- recurcive replace based on context
+        // 1. materialize parameters -- recursive replace based on context
+
         action.updateParameters(recursiveReplace(action.parameters, context.data));
 
         let result = { contextWrites: [], apiCalls: [], actionReports: [] };
         //2. evaluate action
         try {
-          result = Object.assign(result, await action.eval(context));
+          result = Object.assign(result, await action.eval(context, stepTimeoutSeconds));
         } catch (e) {
           result.actionReports = [
             {

--- a/src/models/actions/Http.js
+++ b/src/models/actions/Http.js
@@ -16,7 +16,7 @@ class Http extends BaseAction {
     }
   }
 
-  async eval(context) {
+  async eval(context, stepTimeoutSeconds = 15) {
     // fetch axios instance from context or create one if does not exist
     // this "shared" axios instance is used to ensure that cookies are properly passed between requests
     let transport;
@@ -47,7 +47,8 @@ class Http extends BaseAction {
     let response;
     const t0 = performance.now();
     let requestObj;
-    const timeoutSeconds = (this.parameters.options && this.parameters.options.timeout) || 15;
+    const timeoutSeconds = (this.parameters.options && this.parameters.options.timeout) || stepTimeoutSeconds;
+
     requestObj = {
       url: this.parameters.url,
       method: this.method,


### PR DESCRIPTION
The step timeout is effectively passed to every step's eval() method, but only the http step  uses it.  By default its passed in from the testing service similar to the test timeout, but unlike the test timeout, it can be overridden on individual http requests via the options object inside the http step.