### PR TITLE
Add retry feature when reporting test results

### DIFF
--- a/src/RapidTest.js
+++ b/src/RapidTest.js
@@ -67,11 +67,13 @@ async function executeTest(testExecution, locationDetails) {
       } catch (e) {
         if (retry >= 10) {
           consola.error(
-            `Failed to report test execution ${testExecution.testExecution.id} (${retry}) times. Giving up.`);
+            `Failed to report test execution ${testExecution.testExecution.id} (${retry}) times. Giving up.`
+          );
           clearInterval(interval);
         } else {
           consola.error(
-            `Failed to report test execution ${testExecution.testExecution.id} (${retry}) times. Retrying...`);
+            `Failed to report test execution ${testExecution.testExecution.id} (${retry}) times. Retrying...`
+          );
           retry += 1;
         }
       }


### PR DESCRIPTION
If the POST request to the testing service fails, wait 3 seconds and retry. Continue to retry up to 10 times before giving up.  This should help reduce the number of tests that fail after they have started.