### PR TITLE
Improve error message for http

### DIFF
--- a/src/models/actions/Http.js
+++ b/src/models/actions/Http.js
@@ -75,13 +75,17 @@ class Http extends BaseAction {
         //request was not successful
         const t1 = performance.now();
         const elapsedTime = t1 - t0;
+        let shortSummary = e.message;
+        if (e.code === "ENOTFOUND") {
+          shortSummary = `Network error - no response from ${this.parameters.url}`;
+        }
         return {
           response,
           actionReports: [
             {
               action: `Http.${this.method.toLowerCase()}`,
               success: false,
-              shortSummary: `Network error - no response from ${this.parameters.url}`,
+              shortSummary,
               longSummary: null,
               time: elapsedTime,
             },


### PR DESCRIPTION


In some cases, the error is not related to the url. For example if you pass a bad header with an empty string it would be better to report as such rather than a network error.


**Example**
Create a basic request and provide a header but don't give it a name. Run the request and it will show a network error even if its a valid url. But we really want to report the reason for the error --in this case its an invalid supplied  header

**Before**
![Screen Shot 2022-01-28 at 11 16 04 AM](https://user-images.githubusercontent.com/3939074/151607752-f1ae4123-0870-46c3-ad86-82ffcd3469f0.png)


**After**
![Screen Shot 2022-01-28 at 11 12 55 AM](https://user-images.githubusercontent.com/3939074/151607661-152bfb82-d9de-47c7-bea7-2a021d2b5db1.png)