### PR TITLE
Remove secrets

### DIFF
--- a/src/RapidRequest.js
+++ b/src/RapidRequest.js
@@ -89,8 +89,8 @@ const processRequest = async (req) => {
 
 const executeRequest = async (request) => {
   const context = new Context({
-    ...(request.testVariables || {}),
     ...(request.envVariables || {}),
+    ...(request.testVariables || {}),
   });
   const transformedRequest = recursiveReplace(request.request, context.data);
 

--- a/src/RapidTest.js
+++ b/src/RapidTest.js
@@ -7,10 +7,13 @@ async function executeTest(testExecution, locationDetails) {
   let error;
   try {
     executable = new TestExecutable(JSON.parse(testExecution.test.code));
-    context = new Context({
-      ...testExecution.envVariables,
-      ...testExecution.testVariables,
-    });
+    context = new Context(
+      {
+        ...testExecution.envVariables,
+        ...testExecution.testVariables,
+      },
+      testExecution.envSecrets // used to mask sensitive context data in the report
+    );
     try {
       testResult = await executable.eval(
         context,
@@ -107,7 +110,7 @@ async function fetchAndExecuteTests({ baseUrl, locationSecret, locationKey, loca
 
   if (logging) consola.info("Test executions:\n");
   // eslint-disable-next-line
-  if (logging) console.info(testExecutions);
+  if (logging) consola.info(testExecutions);
 
   await Promise.all(
     testExecutions.map((testExecution) => {

--- a/src/RapidTest.js
+++ b/src/RapidTest.js
@@ -8,9 +8,8 @@ async function executeTest(testExecution, locationDetails) {
   try {
     executable = new TestExecutable(JSON.parse(testExecution.test.code));
     context = new Context({
-      c: "a",
-      ...testExecution.testVariables,
       ...testExecution.envVariables,
+      ...testExecution.testVariables,
     });
     try {
       testResult = await executable.eval(

--- a/src/models/Context.js
+++ b/src/models/Context.js
@@ -1,6 +1,15 @@
 class Context {
-  constructor(data = {}) {
+  constructor(data = {}, secrets = []) {
     this.data = data;
+    this.secrets = secrets;
+  }
+
+  /**
+   * Return a list of secret values used to filter out
+   * sensitive data from test execution results.
+   */
+  getSecrets() {
+    return this.secrets;
   }
 
   get(path) {

--- a/src/models/actions/Http.js
+++ b/src/models/actions/Http.js
@@ -6,6 +6,7 @@ const axiosCookieJarSupport = require("axios-cookiejar-support").default;
 const tough = require("tough-cookie");
 const { performance } = require("perf_hooks");
 const xmlConvert = require("xml-js");
+const { removeSensitiveData } = require("../../utils");
 
 class Http extends BaseAction {
   get method() {
@@ -117,6 +118,9 @@ class Http extends BaseAction {
       rawRequest += typeof requestObj.data == "object" ? JSON.stringify(requestObj.data, null, 4) : requestObj.data;
     }
 
+    // strip all passwords, etc out of the request results
+    const rawRequestCleaned = JSON.parse(removeSensitiveData(JSON.stringify(rawRequest), context.getSecrets()));
+
     return {
       response,
       contextWrites: [{ key: this.parameters.variable, value: response }],
@@ -140,7 +144,7 @@ class Http extends BaseAction {
             {
               responseBody: response.data,
               responseHeaders: response.headers,
-              request: rawRequest,
+              request: rawRequestCleaned,
             },
             null,
             4

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -40,3 +40,21 @@ module.exports.pick = (obj, props) => {
     return o;
   }, {});
 };
+/**
+ * Searches the provided string for any values in the secrets array and replaces
+ * them.
+ */
+module.exports.removeSensitiveData = (stringData, secrets, substitute = "****") => {
+  let cleanData = stringData;
+  function escapeRegExp(string) {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  secrets.forEach((secret) => {
+    const escapedSecret = escapeRegExp(secret);
+    const regexp = new RegExp(escapedSecret, "g");
+    cleanData = cleanData.replace(regexp, substitute);
+  });
+
+  return cleanData;
+};


### PR DESCRIPTION
This is a high priority customer issue related to sensitive data being saved in logs.

## Commits

The order of precedence shall be
Trigger overrides > Test vars > Env vars
- Remove extraneous “c” context var

-------

Filter out sensitive data from HTTP request report](https://github.com/RapidAPI/testing-worker/commit/f6d16d15c48f50a9ccdbb550d7acca537ae02f43) 

The execution report contains verbatim HTTP request data, but this often contains sensitive passwords which should be filtered out.