### PR TITLE
Add test fragment support

### DIFF
--- a/src/models/Context.js
+++ b/src/models/Context.js
@@ -3,9 +3,14 @@ class Context {
     this.data = data;
     this.secrets = secrets;
     this.safeData = {};
+    this.mask = mask;
+    this.maskSafeData();
+  }
+
+  maskSafeData() {
     for (const key of Object.keys(this.data)) {
       if (this.secrets[key]) {
-        this.safeData[key] = mask;
+        this.safeData[key] = this.mask;
       } else {
         this.safeData[key] = this.data[key];
       }
@@ -30,6 +35,8 @@ class Context {
 
   set(key, value) {
     this.data[key] = value;
+    // rebuild safeData from new data
+    this.maskSafeData();
   }
 }
 

--- a/src/models/Context.js
+++ b/src/models/Context.js
@@ -19,12 +19,12 @@ class Context {
 
   copy() {
     const cleanedData = {
-      ...this.data
+      ...this.data,
     };
     // Don't copy the transport object, this should be recreated for each successive http request.
     delete cleanedData.__http_transport;
 
-    return new Context(cleanedData, {...this.secrets}, this.mask);
+    return new Context(cleanedData, { ...this.secrets }, this.mask);
   }
 
   /**

--- a/src/models/Context.js
+++ b/src/models/Context.js
@@ -17,6 +17,16 @@ class Context {
     }
   }
 
+  copy() {
+    const cleanedData = {
+      ...this.data
+    };
+    // Don't copy the transport object, this should be recreated for each successive http request.
+    delete cleanedData.__http_transport;
+
+    return new Context(cleanedData, {...this.secrets}, this.mask);
+  }
+
   /**
    * Return a list of secret values used to perform ad-hoc filtered of
    * sensitive data after templates has been processed.

--- a/src/models/TestExecutable.js
+++ b/src/models/TestExecutable.js
@@ -27,6 +27,7 @@ const actionClasses = {
   "Assert.greater_equal": require("./actions/AssertGreaterEqual").AssertGreaterEqual,
   "Assert.smaller_equal": require("./actions/AssertSmallerEqual").AssertSmallerEqual,
   "Connector.database": require("./actions/Database").Database,
+  "Execute.Fragment": require("./actions/ExecuteFragment").ExecuteFragment,
 };
 
 class TestExecutable {
@@ -44,6 +45,8 @@ class TestExecutable {
       let MaterialClass = actionClasses[step.action];
       let materialStep = new MaterialClass(step.parameters);
       materialStep.action = step.action;
+      materialStep.errorFromService = step.errorFromService || null; // used to force a pre-execution error from the testing service.
+
       if (Object.prototype.hasOwnProperty.call(step, "children")) {
         materialStep.children = new TestExecutable(step.children);
       }
@@ -57,6 +60,7 @@ class TestExecutable {
     var cancelled = false;
 
     let actions = this.actions.map((a) => Object.assign(Object.create(Object.getPrototypeOf(a)), a)); //deep clone actions so parameter materialization is scoped
+
     let _apiCalls = [];
     let _actionReports = [];
 

--- a/src/models/actions/BaseAction.js
+++ b/src/models/actions/BaseAction.js
@@ -1,7 +1,9 @@
 class BaseAction {
   constructor(parameters = {}) {
     this.parameters = { ...parameters };
-    this.safeParameters = { ...parameters };
+    // make a deep copy
+    var copy = JSON.parse(JSON.stringify(parameters));
+    this.safeParameters = copy;
   }
 
   updateParameters(parameters) {

--- a/src/models/actions/BaseAction.js
+++ b/src/models/actions/BaseAction.js
@@ -4,6 +4,7 @@ class BaseAction {
     // make a deep copy
     var copy = JSON.parse(JSON.stringify(parameters));
     this.safeParameters = copy;
+    this.errorFromService = null;
   }
 
   updateParameters(parameters) {

--- a/src/models/actions/ExecuteFragment.js
+++ b/src/models/actions/ExecuteFragment.js
@@ -1,0 +1,58 @@
+const { performance } = require("perf_hooks");
+const { BaseAction } = require("./BaseAction");
+
+class ExecuteFragment extends BaseAction {
+  async eval(context) {
+    const t0 = performance.now();
+
+    if (this.errorFromService) {
+      return {
+        actionReports: [
+          {
+            action: "Execute.Fragment",
+            success: false,
+            shortSummary: this.errorFromService,
+            longSummary: null,
+            time: performance.now() - t0,
+          },
+        ],
+      };
+    }
+    try {
+      // Make a copy so changes to the context affect only nested tests.
+      const copyContext = context.copy();
+
+      // Test variables not defined by the fragment will be undefined when executed
+      // from a parent test unless mapped in the fragments inputs.
+      //
+      // The context will contain all secrets, env vars and upstream context results in
+      // addition to the input overrides from the fragment. Child test variables are not
+      // available and will remain undefined unless the input overrides for them are passed.
+      //
+      for (const variable in this.parameters.inputs) {
+        copyContext.set(variable, this.parameters.inputs[variable]);
+      }
+
+      const { apiCalls, actionReports } = await this.children.eval(copyContext);
+
+      return {
+        apiCalls,
+        actionReports: [...actionReports],
+      };
+    } catch (e) {
+      return {
+        actionReports: [
+          {
+            action: "Execute.Fragment",
+            success: false,
+            shortSummary: e.message,
+            longSummary: null,
+            time: performance.now() - t0,
+          },
+        ],
+      };
+    }
+  }
+}
+
+module.exports = { ExecuteFragment };

--- a/src/models/actions/ExecuteFragment.spec.js
+++ b/src/models/actions/ExecuteFragment.spec.js
@@ -11,6 +11,7 @@ describe("ExecuteFragment", () => {
     $action.children = {
       // fake sub-test
       eval: sinon.fake.returns({
+        contextWrites: [],
         apiCalls: [{}],
         actionReports: [
           {
@@ -24,6 +25,31 @@ describe("ExecuteFragment", () => {
     let $context = new Context({ varName: "hello" });
     let $result = await $action.eval($context);
     expect($result.actionReports[0].action).toBe("My.action");
+  });
+
+  it("should pass contextWrites array with scoped variable", async () => {
+    let $action = new ExecuteFragment({
+      testId: "test_1234",
+      variable: "childContext",
+      inputs: {},
+    });
+    $action.children = {
+      // fake sub-test
+      eval: sinon.fake.returns({
+        contextWrites: [{ key: "foo", value: "bar" }],
+        apiCalls: [{}],
+        actionReports: [
+          {
+            action: "My.action",
+            success: true,
+          },
+        ],
+      }),
+    };
+
+    let $context = new Context({ varName: "hello" });
+    let $result = await $action.eval($context);
+    expect($result.contextWrites).toEqual([{ key: "childContext", value: { foo: "bar" } }]);
   });
 
   it("should not override the context when vars don't match", async () => {

--- a/src/models/actions/ExecuteFragment.spec.js
+++ b/src/models/actions/ExecuteFragment.spec.js
@@ -1,0 +1,104 @@
+const { ExecuteFragment } = require("./ExecuteFragment");
+const Context = require("../Context");
+const sinon = require("sinon");
+
+describe("ExecuteFragment", () => {
+  it("should return successful result and execute `children`", async () => {
+    let $action = new ExecuteFragment({
+      testId: "test_1234",
+      inputs: {},
+    });
+    $action.children = {
+      // fake sub-test
+      eval: sinon.fake.returns({
+        apiCalls: [{}],
+        actionReports: [
+          {
+            action: "My.action",
+            success: true,
+          },
+        ],
+      }),
+    };
+
+    let $context = new Context({ varName: "hello" });
+    let $result = await $action.eval($context);
+    expect($result.actionReports[0].action).toBe("My.action");
+  });
+
+  it("should not override the context when vars don't match", async () => {
+    let $action = new ExecuteFragment({
+      testId: "test_1234",
+      inputs: {
+        varName2: "bye", // varName2 != varName
+      },
+    });
+    $action.children = {
+      // fake sub-test
+      eval: sinon.spy(
+        sinon.fake.returns({
+          apiCalls: [],
+          actionReports: [{ action: "fake", success: true }],
+        })
+      ),
+    };
+
+    let $context = new Context({ varName: "hello" });
+    await $action.eval($context);
+    expect($action.children.eval.args[0][0].data.varName).toBe("hello");
+  });
+
+  it("should override the context vars when passed", async () => {
+    let $action = new ExecuteFragment({
+      testId: "test_1234",
+      inputs: {
+        varName: "bye",
+      },
+    });
+    $action.children = {
+      // fake sub-test
+      eval: sinon.spy(
+        sinon.fake.returns({
+          apiCalls: [],
+          actionReports: [{ action: "fake", success: true }],
+        })
+      ),
+    };
+
+    let $context = new Context({ varName: "hello" });
+    await $action.eval($context);
+    expect($action.children.eval.args[0][0].data.varName).toBe("bye");
+  });
+
+  it("should create an error step if `errorFromService` is passed", async () => {
+    let $action = new ExecuteFragment({
+      testId: "test_1234",
+      inputs: {
+        varName: "bye",
+      },
+    });
+    $action.errorFromService = "this is an error!";
+
+    let $context = new Context({});
+    let $result = await $action.eval($context);
+    expect($result.actionReports[0].action).toBe("Execute.Fragment");
+    expect($result.actionReports[0].success).toBe(false);
+    expect($result.actionReports[0].shortSummary).toBe("this is an error!");
+  });
+
+  it("should return an error if `children` are missing", async () => {
+    let $action = new ExecuteFragment({
+      testId: "test_1234",
+      inputs: {
+        varName: "bye",
+      },
+    });
+
+    let $context = new Context({});
+    let $result = await $action.eval($context);
+    expect($result.actionReports[0].action).toBe("Execute.Fragment");
+    expect($result.actionReports[0].success).toBe(false);
+    expect(typeof $result.actionReports[0].shortSummary).toBe("string");
+    expect($result.actionReports[0].longSummary).toBe(null);
+  });
+});


### PR DESCRIPTION
Update: This is re-based using this branch

Please review this first
https://github.com/RapidAPI/testing-worker/pull/31


Here is what we want the Context to do

**Child 1**
```
Context: {foo: "bar"}
variable: "myChild"
```

**Child 2**
```
Context: {foo: "bar2"}
variable: "myOtherChild"
```


**Parent**
Context (pre-child execution):
```
{baz: "zap"}
```
Contex (post-child execution)
```
{
  baz: "zap",
  myChild: {foo: "bar"}
  myOtherChild: {foo: "bar2"}
}
```