### PR TITLE
Fix error when returning non JSON strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rapidapi/testing-worker",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "A RapidAPI Testing worker CLI",
   "private": false,
   "license": "MIT",

--- a/src/models/TestExecutable.js
+++ b/src/models/TestExecutable.js
@@ -92,7 +92,7 @@ class TestExecutable {
               action: action.action,
               success: false,
               shortSummary: e.message,
-              longSummary: e,
+              longSummary: null,
               time: 0,
             },
           ];

--- a/src/models/actions/FakerGenerate.spec.js
+++ b/src/models/actions/FakerGenerate.spec.js
@@ -113,7 +113,7 @@ describe("FakerGenerate", () => {
       expect($result.actionReports[0].shortSummary).not.toContain("Invalid");
     });
 
-    it.only("should pass undefined for missing params", async () => {
+    it("should pass undefined for missing params", async () => {
       let $action = new FakerGenerate({
         variable: "b",
         category: "date",

--- a/src/models/actions/LogicIf.js
+++ b/src/models/actions/LogicIf.js
@@ -69,7 +69,7 @@ class LogicIf extends BaseAction {
             action: "Logic.if",
             success: false,
             shortSummary: e.message,
-            longSummary: e,
+            longSummary: null,
             time: performance.now() - t0,
           },
         ],

--- a/src/models/actions/LogicIf.spec.js
+++ b/src/models/actions/LogicIf.spec.js
@@ -57,9 +57,29 @@ describe("LogicIf", () => {
     };
     let $context = new Context({ varName: 815 });
     await $action.eval($context);
-
     expect($action.children.eval.called).toBeFalsy();
   });
+});
+
+it("should return an error if operator is invalid", async () => {
+  let $action = new LogicIf({
+    key: "a",
+    operator: "not_valid",
+    value: "a",
+  });
+  $action.children = {
+    eval: sinon.fake.returns({ apiCalls: [], actionReports: [] }),
+  };
+  let $context = new Context({ varName: 815 });
+  let $result = await $action.eval($context);
+
+  expect($result.actionReports.length).toBe(1);
+  expect($result.actionReports[0].action).toBe("Logic.if");
+  expect($result.actionReports[0].success).toBe(false);
+  // eslint-disable-next-line no-useless-escape
+  expect($result.actionReports[0].shortSummary).toBe('Testing for undefined operator "not_valid"');
+  expect(typeof $result.actionReports[0].time).toBe("number");
+  expect($result.actionReports[0].longSummary).toBe(null);
 });
 
 describe("compare()", () => {

--- a/src/models/actions/LoopFor.js
+++ b/src/models/actions/LoopFor.js
@@ -29,7 +29,8 @@ class LoopForEach extends BaseAction {
             action: "Loop.forEach",
             success: false,
             shortSummary: `Object at ${this.parameters.expression} is not an array`,
-            longSummary: `Expected an array, instead got ${typeof arr} with value: ${arr}`,
+            longSummary: JSON.stringify({ summary: `Expected an array, instead got ${typeof arr} with value: ${arr}` }),
+            //longSummary: null,
             time: performance.now() - t0,
           },
         ],
@@ -55,7 +56,7 @@ class LoopForEach extends BaseAction {
     result.actionReports.unshift({
       action: "Loop.forEach",
       success: failedCount == 0,
-      shortSummary: `Itterated over ${arr.length} elements in array ${this.parameters.expression}. ${
+      shortSummary: `Iterated over ${arr.length} elements in array ${this.parameters.expression}. ${
         result.actionReports.length - failedCount
       }/${result.actionReports.length} steps passed.`,
       longSummary: null,

--- a/src/models/actions/LoopFor.spec.js
+++ b/src/models/actions/LoopFor.spec.js
@@ -80,7 +80,7 @@ describe("LoopForEach", () => {
     expect($result.actionReports.length).toBe(1);
     expect($result.actionReports[0].action).toBe("Loop.forEach");
     expect($result.actionReports[0].success).toBe(false);
-
+    expect(typeof $result.actionReports[0].longSummary).toBe("string");
     expect($action.children.eval.callCount).toBe(0);
   });
 });

--- a/src/models/actions/MiscGroup.js
+++ b/src/models/actions/MiscGroup.js
@@ -18,7 +18,7 @@ class MiscGroup extends BaseAction {
             action: "Misc.group",
             success: false,
             shortSummary: e.message,
-            longSummary: e,
+            longSummary: null,
             time: performance.now() - t0,
           },
         ],


### PR DESCRIPTION
- longsummary must be a json string in all cases
- In the generic error cases, we don’t need to pass the error object to the user as we already pass the message in the shortSummary.