### PR TITLE
Pass contextWrites to parent

### DIFF
--- a/src/models/TestExecutable.js
+++ b/src/models/TestExecutable.js
@@ -55,7 +55,7 @@ class TestExecutable {
     this.actions = actions;
   }
 
-  async eval(context, timeoutSeconds = 300, stepTimeoutSeconds = 15, passContextWrites = false) {
+  async eval(context, timeoutSeconds = 300, stepTimeoutSeconds = 15) {
     var cancelled = false;
 
     let actions = this.actions.map((a) => Object.assign(Object.create(Object.getPrototypeOf(a)), a)); //deep clone actions so parameter materialization is scoped
@@ -110,11 +110,11 @@ class TestExecutable {
         for (let cw of result.contextWrites) {
           context.set(cw.key, cw.value);
         }
-        if (passContextWrites) {
-          // Pass up the context so it can be written to the parent. This option
-          // should only be used when using a copy the parent's context
-          totalContextWrites.push(...result.contextWrites);
-        }
+
+        // 5. Pass up the context. In most cases this will be redundant; however,
+        // this does need to bubble to the top for child tests to be correctly scoped
+        // into a parent.
+        totalContextWrites.push(...result.contextWrites);
       }
       return FINISHED_EXECUTION;
     })();

--- a/src/models/actions/ExecuteFragment.js
+++ b/src/models/actions/ExecuteFragment.js
@@ -37,8 +37,7 @@ class ExecuteFragment extends BaseAction {
       const { apiCalls, actionReports, contextWrites } = await this.children.eval(
         copyContext,
         timeoutSeconds,
-        stepTimeoutSeconds,
-        true
+        stepTimeoutSeconds
       );
 
       const childContext = contextWrites.reduce((prev, current) => {

--- a/src/models/actions/LogicIf.js
+++ b/src/models/actions/LogicIf.js
@@ -35,8 +35,9 @@ class LogicIf extends BaseAction {
       let comparisonResult = compare(key, operator, value);
 
       if (comparisonResult) {
-        let { apiCalls, actionReports } = await this.children.eval(context);
+        let { apiCalls, actionReports, contextWrites } = await this.children.eval(context);
         return {
+          contextWrites,
           apiCalls,
           actionReports: [
             {

--- a/src/models/actions/LogicIf.spec.js
+++ b/src/models/actions/LogicIf.spec.js
@@ -10,7 +10,11 @@ describe("LogicIf", () => {
       value: "a",
     });
     $action.children = {
-      eval: sinon.fake.returns({ apiCalls: [], actionReports: [] }),
+      eval: sinon.fake.returns({
+        apiCalls: [],
+        actionReports: [],
+        contextWrites: [],
+      }),
     };
     let $context = new Context({ varName: 815 });
     let $result = await $action.eval($context);
@@ -24,6 +28,24 @@ describe("LogicIf", () => {
     expect($action.children.eval.called).toBeTruthy();
   });
 
+  it("should pass contextWrites from child eval", async () => {
+    let $action = new LogicIf({
+      key: "a",
+      operator: "==",
+      value: "a",
+    });
+    $action.children = {
+      eval: sinon.fake.returns({
+        apiCalls: [],
+        actionReports: [],
+        contextWrites: [{ key: "var", value: "foo" }],
+      }),
+    };
+    let $context = new Context({});
+    let $result = await $action.eval($context);
+    expect($result.contextWrites).toEqual([{ key: "var", value: "foo" }]);
+  });
+
   it("should chain results from children nodes", async () => {
     let $action = new LogicIf({
       key: "a",
@@ -34,6 +56,7 @@ describe("LogicIf", () => {
       eval: sinon.fake.returns({
         apiCalls: [],
         actionReports: [{ action: "fake" }],
+        contextWrites: [],
       }),
     };
     let $context = new Context({ varName: 815 });
@@ -68,7 +91,11 @@ it("should return an error if operator is invalid", async () => {
     value: "a",
   });
   $action.children = {
-    eval: sinon.fake.returns({ apiCalls: [], actionReports: [] }),
+    eval: sinon.fake.returns({
+      apiCalls: [],
+      actionReports: [],
+      contextWrites: [],
+    }),
   };
   let $context = new Context({ varName: 815 });
   let $result = await $action.eval($context);

--- a/src/models/actions/LoopFor.js
+++ b/src/models/actions/LoopFor.js
@@ -38,6 +38,7 @@ class LoopForEach extends BaseAction {
     }
 
     let result = {
+      contextWrites: [],
       actionReports: [],
       apiCalls: [],
     };
@@ -45,9 +46,12 @@ class LoopForEach extends BaseAction {
     const elemName = this.parameters.variable;
 
     for (let elem of arr) {
+      // the loop variable is local only, this won't be passed up in contextWrites arrays
       context.set(elemName, elem);
-      let { apiCalls, actionReports } = await this.children.eval(context);
+
+      let { apiCalls, actionReports, contextWrites } = await this.children.eval(context);
       result.actionReports.push(...actionReports);
+      result.contextWrites.push(...contextWrites);
       result.apiCalls.push(...apiCalls);
     }
 

--- a/src/models/actions/LoopFor.spec.js
+++ b/src/models/actions/LoopFor.spec.js
@@ -9,7 +9,13 @@ describe("LoopForEach", () => {
       variable: "var",
     });
     $action.children = {
-      eval: sinon.spy(sinon.fake.returns({ apiCalls: [], actionReports: [] })),
+      eval: sinon.spy(
+        sinon.fake.returns({
+          apiCalls: [],
+          actionReports: [],
+          contextWrites: [],
+        })
+      ),
     };
     let $context = new Context({ arr: [1, 2, 3, 4, 5] });
     let $result = await $action.eval($context);
@@ -31,6 +37,7 @@ describe("LoopForEach", () => {
         sinon.fake.returns({
           apiCalls: [],
           actionReports: [{ action: "fake", success: true }],
+          contextWrites: [],
         })
       ),
     };
@@ -48,13 +55,44 @@ describe("LoopForEach", () => {
     expect($action.children.eval.callCount).toBe(5);
   });
 
+  it("should pass contextWrites for each loop", async () => {
+    let $action = new LoopForEach({
+      expression: "arr",
+      variable: "var",
+    });
+    $action.children = {
+      eval: sinon.spy(
+        sinon.fake.returns({
+          apiCalls: [],
+          actionReports: [{ action: "fake", success: true }],
+          contextWrites: [{ key: "var", value: "foo" }],
+        })
+      ),
+    };
+    let $context = new Context({ arr: [1, 2, 3, 4, 5] });
+    let $result = await $action.eval($context);
+    expect($result.contextWrites).toEqual([
+      { key: "var", value: "foo" },
+      { key: "var", value: "foo" },
+      { key: "var", value: "foo" },
+      { key: "var", value: "foo" },
+      { key: "var", value: "foo" },
+    ]);
+  });
+
   it("should return error if array does not exist", async () => {
     let $action = new LoopForEach({
       expression: "missing_arr",
       variable: "var",
     });
     $action.children = {
-      eval: sinon.spy(sinon.fake.returns({ apiCalls: [], actionReports: [] })),
+      eval: sinon.spy(
+        sinon.fake.returns({
+          apiCalls: [],
+          actionReports: [],
+          contextWrites: [],
+        })
+      ),
     };
     let $context = new Context({ arr: [1, 2, 3, 4, 5] });
     let $result = await $action.eval($context);
@@ -72,7 +110,13 @@ describe("LoopForEach", () => {
       variable: "var",
     });
     $action.children = {
-      eval: sinon.spy(sinon.fake.returns({ apiCalls: [], actionReports: [] })),
+      eval: sinon.spy(
+        sinon.fake.returns({
+          apiCalls: [],
+          actionReports: [],
+          contextWrites: [],
+        })
+      ),
     };
     let $context = new Context({ not_an_arr: "Lo" });
     let $result = await $action.eval($context);

--- a/src/models/actions/MiscGroup.js
+++ b/src/models/actions/MiscGroup.js
@@ -6,8 +6,9 @@ class MiscGroup extends BaseAction {
     const t0 = performance.now();
 
     try {
-      let { apiCalls, actionReports } = await this.children.eval(context);
+      let { apiCalls, actionReports, contextWrites } = await this.children.eval(context);
       return {
+        contextWrites,
         apiCalls,
         actionReports,
       };

--- a/src/models/actions/MiscGroup.spec.js
+++ b/src/models/actions/MiscGroup.spec.js
@@ -1,0 +1,19 @@
+const { MiscGroup } = require("./MiscGroup");
+const Context = require("../Context");
+const sinon = require("sinon");
+
+describe("MiscGroup", () => {
+  it("should pass contextWrites from child eval", async () => {
+    let $action = new MiscGroup({});
+    $action.children = {
+      eval: sinon.fake.returns({
+        apiCalls: [],
+        actionReports: [],
+        contextWrites: [{ key: "var", value: "foo" }],
+      }),
+    };
+    let $context = new Context({});
+    let $result = await $action.eval($context);
+    expect($result.contextWrites).toEqual([{ key: "var", value: "foo" }]);
+  });
+});


### PR DESCRIPTION
Found a day 1 bug with test fragments which preventing the context from being correctly assigned when child tests had loops, if or groups

### Commit
--------
- `1.` Loop, `2.` If, and `3.` Group should all pass the contextWrites up to the TestExecution caller.

- Remove optional passContextWrites from TestExecution and pass it up in all cases. In many cases this will largely be redundant because all child steps that set the context will also execute prior to the parent receiving the contextWrites array, however, in cases of test Fragments, the parent’s Context is not the same instance so we need to perform a second write. In order to do that, we need the contextWrites array to always bubble up.
