### PR TITLE
Fix CodeRun

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": false,
   "license": "MIT",
   "scripts": {
-    "worker:local:interval": "node src/main.js",
+    "worker:local:interval": "node --unhandled-rejections=strict src/main.js",
     "lint": "yarn eslint src/**",
     "format": "yarn prettier -w src/**",
     "check-format": "yarn prettier -c src/**",


### PR DESCRIPTION
- CodeRun has two module  vars which were global to the module, but they need to be scoped to the instance of the CodeRun class currently running otherwise multiple CodeRuns will complete and use the same vars. This could happen if a work execute 2 or more tests with CodeRuns in the same batch or a single test which has multiple CodeRun steps. This could also happen with multiple calls to child tests with CodeRuns.

- Additionally, the uncaughtException was not fully working because node needs the `unhandled-rejections=strict` param which will trigger this event when an uncaught exception is thrown.

- Move the uncaughtException callback to be inside the CodeRun eval function so it can bind with the scope of the function and have access to `this` so it can call this.resolve() and fail the test with the uncaughtException error message from node.