### PR TITLE
Fix timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rapidapi/testing-worker",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A RapidAPI Testing worker CLI",
   "private": false,
   "license": "MIT",

--- a/src/models/actions/JsonValidate.spec.js
+++ b/src/models/actions/JsonValidate.spec.js
@@ -102,7 +102,7 @@ describe("JsonValidate", () => {
     expect(typeof $result.actionReports[0].time).toBe("number");
   });
 
-  it.only("should fail result when the formatter validation fails", async () => {
+  it("should fail result when the formatter validation fails", async () => {
     let $action = new JsonValidate({
       expression: "foo",
       schema: JSON.stringify({

--- a/src/models/actions/LogicIf.js
+++ b/src/models/actions/LogicIf.js
@@ -27,7 +27,7 @@ function compare(val1, operator, val2) {
 }
 
 class LogicIf extends BaseAction {
-  async eval(context) {
+  async eval(context, timeoutSeconds = 300, stepTimeoutSeconds = 15) {
     const t0 = performance.now();
     let { key, value, operator } = this.parameters;
 
@@ -35,7 +35,11 @@ class LogicIf extends BaseAction {
       let comparisonResult = compare(key, operator, value);
 
       if (comparisonResult) {
-        let { apiCalls, actionReports, contextWrites } = await this.children.eval(context);
+        let { apiCalls, actionReports, contextWrites } = await this.children.eval(
+          context,
+          timeoutSeconds,
+          stepTimeoutSeconds
+        );
         return {
           contextWrites,
           apiCalls,

--- a/src/models/actions/LogicIf.spec.js
+++ b/src/models/actions/LogicIf.spec.js
@@ -46,6 +46,22 @@ describe("LogicIf", () => {
     expect($result.contextWrites).toEqual([{ key: "var", value: "foo" }]);
   });
 
+  it("should pass context and timeouts to child eval", async () => {
+    let $action = new LogicIf({
+      key: "a",
+      operator: "==",
+      value: "a",
+    });
+    $action.children = {
+      eval: sinon.stub(),
+    };
+    let $context = new Context({ a: 1 });
+    await $action.eval($context, 100, 10);
+    expect($action.children.eval.getCall(0).args[0].data).toEqual({ a: 1 });
+    expect($action.children.eval.getCall(0).args[1]).toEqual(100);
+    expect($action.children.eval.getCall(0).args[2]).toEqual(10);
+  });
+
   it("should chain results from children nodes", async () => {
     let $action = new LogicIf({
       key: "a",

--- a/src/models/actions/LoopFor.js
+++ b/src/models/actions/LoopFor.js
@@ -2,7 +2,7 @@ const { BaseAction } = require("./BaseAction");
 const { performance } = require("perf_hooks");
 
 class LoopForEach extends BaseAction {
-  async eval(context) {
+  async eval(context, timeoutSeconds = 300, stepTimeoutSeconds = 15) {
     const t0 = performance.now();
     let arr;
 
@@ -48,8 +48,11 @@ class LoopForEach extends BaseAction {
     for (let elem of arr) {
       // the loop variable is local only, this won't be passed up in contextWrites arrays
       context.set(elemName, elem);
-
-      let { apiCalls, actionReports, contextWrites } = await this.children.eval(context);
+      let { apiCalls, actionReports, contextWrites } = await this.children.eval(
+        context,
+        timeoutSeconds,
+        stepTimeoutSeconds
+      );
       result.actionReports.push(...actionReports);
       result.contextWrites.push(...contextWrites);
       result.apiCalls.push(...apiCalls);

--- a/src/models/actions/LoopFor.spec.js
+++ b/src/models/actions/LoopFor.spec.js
@@ -55,6 +55,29 @@ describe("LoopForEach", () => {
     expect($action.children.eval.callCount).toBe(5);
   });
 
+  it("should pass timeouts to childrens' eval", async () => {
+    let $action = new LoopForEach({
+      expression: "arr",
+      variable: "var",
+    });
+    $action.children = {
+      eval: sinon.spy(
+        sinon.fake.returns({
+          apiCalls: [],
+          actionReports: [],
+          contextWrites: [],
+        })
+      ),
+    };
+    let $context = new Context({ arr: [1, 2, 3, 4, 5] });
+    await $action.eval($context, 100, 10);
+
+    for (let i = 0; i < 5; i++) {
+      expect($action.children.eval.getCall(i).args[1]).toEqual(100);
+      expect($action.children.eval.getCall(i).args[2]).toEqual(10);
+    }
+  });
+
   it("should pass contextWrites for each loop", async () => {
     let $action = new LoopForEach({
       expression: "arr",

--- a/src/models/actions/MiscGroup.js
+++ b/src/models/actions/MiscGroup.js
@@ -2,11 +2,15 @@ const { BaseAction } = require("./BaseAction");
 const { performance } = require("perf_hooks");
 
 class MiscGroup extends BaseAction {
-  async eval(context) {
+  async eval(context, timeoutSeconds = 300, stepTimeoutSeconds = 15) {
     const t0 = performance.now();
 
     try {
-      let { apiCalls, actionReports, contextWrites } = await this.children.eval(context);
+      let { apiCalls, actionReports, contextWrites } = await this.children.eval(
+        context,
+        timeoutSeconds,
+        stepTimeoutSeconds
+      );
       return {
         contextWrites,
         apiCalls,

--- a/src/models/actions/MiscGroup.spec.js
+++ b/src/models/actions/MiscGroup.spec.js
@@ -16,4 +16,16 @@ describe("MiscGroup", () => {
     let $result = await $action.eval($context);
     expect($result.contextWrites).toEqual([{ key: "var", value: "foo" }]);
   });
+
+  it("should pass context and timeouts to child eval", async () => {
+    let $action = new MiscGroup({});
+    $action.children = {
+      eval: sinon.stub(),
+    };
+    let $context = new Context({ a: 1 });
+    await $action.eval($context, 100, 10);
+    expect($action.children.eval.getCall(0).args[0].data).toEqual({ a: 1 });
+    expect($action.children.eval.getCall(0).args[1]).toEqual(100);
+    expect($action.children.eval.getCall(0).args[2]).toEqual(10);
+  });
 });


### PR DESCRIPTION
Group, If and For could possible contain a child step that requires either the timeout or stepTimeout. In such cases the values were not being passed which would then revert tot he default values. This lead to confusing and incorrect behavior.

I confirmed that the timeout values get correctly passed down in if/for and groups now.

