### PR TITLE
Add redirect block feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rapidapi/testing-worker",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "A RapidAPI Testing worker CLI",
   "private": false,
   "license": "MIT",

--- a/src/RapidRequest.js
+++ b/src/RapidRequest.js
@@ -69,11 +69,14 @@ const sendRequestResult = async (
   }
 };
 
-const processRequest = async (req) => {
+const processRequest = async (req, allowRedirects = true) => {
   const mockContext = new Context({});
   req.payload = req.data;
   const action = new Http(req);
-  const result = await action.eval(mockContext);
+
+  const TEST_TIMEOUT = 0; // this is not used for the Http action, value is irrelevant
+  const STEP_TIMEOUT = 15; // requests always use default step timeout, tests can override this value however
+  const result = await action.eval(mockContext, TEST_TIMEOUT, STEP_TIMEOUT, allowRedirects);
   const executionTime = result.actionReports && result.actionReports.length > 0 && result.actionReports[0].time;
   if (!result.response) {
     // Cases where the DNS can not resolve or we don't get a response from the server.
@@ -95,7 +98,7 @@ const processRequest = async (req) => {
   }
 };
 
-const executeRequest = async (request) => {
+const executeRequest = async (request, allowRedirects = true) => {
   const context = new Context(
     {
       ...(request.envVariables || {}),
@@ -106,7 +109,7 @@ const executeRequest = async (request) => {
 
   const transformedRequest = recursiveReplace(request.request, context.data);
 
-  return await processRequest(transformedRequest);
+  return await processRequest(transformedRequest, allowRedirects);
 };
 
 const executeAndSendRequest = async (request, locationDetails) => {

--- a/src/models/actions/Http.js
+++ b/src/models/actions/Http.js
@@ -39,21 +39,28 @@ class Http extends BaseAction {
   }
 
   // eslint-disable-next-line no-unused-vars
-  async eval(context, timeoutSeconds = 300, stepTimeoutSeconds = 15) {
+  async eval(context, timeoutSeconds = 300, stepTimeoutSeconds = 15, allowRedirects = true) {
     // fetch axios instance from context or create one if does not exist
     // this "shared" axios instance is used to ensure that cookies are properly passed between requests
     let transport;
+
+    // Security measure to prevent redirects when used in an environment with access
+    // to sensitive information.
+    const maxRedirects = allowRedirects ? 5 : 0; // 5 is the axios default
+
     try {
       transport = context.get("__http_transport");
     } catch (e) {
       if (global.settings?.ignoreSSL === "false" || !global.settings) {
         transport = axios.create({
           withCredentials: true,
+          maxRedirects,
         });
       } else {
         // Allow self-signed or missing SSL certs
         transport = axios.create({
           withCredentials: true,
+          maxRedirects,
           httpsAgent: new https.Agent({
             rejectUnauthorized: false,
           }),


### PR DESCRIPTION
**Problem 1**

An attacker could use a DNS to resolve a domain to AWS internal meta data IP. This issue has been fixed in our testing repo

**Problem 2 (what this PR address)**

A similar attack could also happen with a simple redirect. There really is no reason to allow redirects when using the `request/proxy` endpoint for Webhooks so I added a way to pass a param to disable it. This only affects this endpoint in our testing service and won't have any effects to the lambda workers which already can't access any internal URLs.



BEFORE (redirect followed)
<img width="927" alt="Screen Shot 2023-03-02 at 1 50 50 PM" src="https://user-images.githubusercontent.com/3939074/222567680-5e6c6982-2127-4d41-9927-9f99fe52d7bf.png">

AFTER (redirect not followed)
<img width="910" alt="Screen Shot 2023-03-02 at 1 50 08 PM" src="https://user-images.githubusercontent.com/3939074/222567673-fd1e9427-fe74-428d-ad86-2067ecbf1728.png">


Note.  i had to hack up the testing service a bit to even allow localhost to work, but it was helpful as I created a redirect on another server. You can see before and after the changes here along with some changes to the testing service code will be required after this PR.

