### PR TITLE
Remove access token

### DIFF
--- a/.github/actions/build-zip/action.yml
+++ b/.github/actions/build-zip/action.yml
@@ -1,8 +1,8 @@
 name: "Build zip"
 
 inputs:
-  ACTIONS_ACCESS_KEY:
-    description: "secrets.ACTIONS_ACCESS_KEY"
+  GITHUB_TOKEN:
+    description: "secrets.GITHUB_TOKEN"
     required: true
 
 runs:
@@ -16,7 +16,7 @@ runs:
       shell: "bash"
       run: cd ../dist && yarn install --frozen-lockfile
       env:
-        NODE_AUTH_TOKEN: ${{ inputs.ACTIONS_ACCESS_KEY }}
+        NODE_AUTH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
     # Kind of a hack to avoid recursively copying the dist folder
     - name: Move dist folder down
       shell: "bash"
@@ -24,8 +24,8 @@ runs:
     - name: Zip dist
       shell: "bash"
       run: zip -rq worker.zip dist/*
-    # - name: Upload the zipped worker
-    #   uses: actions/upload-artifact@v2
-    #   with:
-    #     name: zipped_worker
-    #     path: worker.zip
+    - name: Upload the zipped worker
+      uses: actions/upload-artifact@v2
+      with:
+        name: zipped_worker
+        path: worker.zip

--- a/.github/actions/build-zip/action.yml
+++ b/.github/actions/build-zip/action.yml
@@ -24,8 +24,8 @@ runs:
     - name: Zip dist
       shell: "bash"
       run: zip -rq worker.zip dist/*
-    - name: Upload the zipped worker
-      uses: actions/upload-artifact@v2
-      with:
-        name: zipped_worker
-        path: worker.zip
+    # - name: Upload the zipped worker
+    #   uses: actions/upload-artifact@v2
+    #   with:
+    #     name: zipped_worker
+    #     path: worker.zip

--- a/.github/actions/build-zip/action.yml
+++ b/.github/actions/build-zip/action.yml
@@ -16,7 +16,7 @@ runs:
       shell: "bash"
       run: cd ../dist && yarn install --frozen-lockfile
       env:
-        NODE_AUTH_TOKEN: ${{inputs.ACTIONS_ACCESS_KEY}}
+        NODE_AUTH_TOKEN: ${{ inputs.ACTIONS_ACCESS_KEY }}
     # Kind of a hack to avoid recursively copying the dist folder
     - name: Move dist folder down
       shell: "bash"

--- a/.github/actions/upload-lambda/action.yml
+++ b/.github/actions/upload-lambda/action.yml
@@ -7,7 +7,7 @@ inputs:
   aws_region:
     description: "The region to deploy the lambda too"
     required: true
-  function_name: 
+  function_name:
     description: "Lambda function name"
     required: true
   aws_access_key_id:
@@ -15,9 +15,6 @@ inputs:
     required: true
   aws_secret_access_key:
     description: "The AWS access secret for the provided region"
-    required: true
-  ACTIONS_ACCESS_KEY:
-    description: "secrets.ACTIONS_ACCESS_KEY"
     required: true
 
 runs:

--- a/.github/workflows/master-change.yml
+++ b/.github/workflows/master-change.yml
@@ -21,7 +21,7 @@ jobs:
       # Build lambda zip
       - uses: ./.github/actions/build-zip
         with:
-          ACTIONS_ACCESS_KEY: ${{ secrets.ACTIONS_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   lambda-upload-zip-to-aws:
     needs: [node-run-tests]
@@ -108,7 +108,7 @@ jobs:
           registry: https://registry.npmjs.org/
       - uses: JS-DevTools/npm-publish@v1
         with:
-          token: ${{ secrets.ACTIONS_ACCESS_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           registry: https://npm.pkg.github.com
 
   make-release:

--- a/.github/workflows/master-change.yml
+++ b/.github/workflows/master-change.yml
@@ -20,9 +20,9 @@ jobs:
       - run: yarn lint
       # Build lambda zip
       - uses: ./.github/actions/build-zip
-        with: 
+        with:
           ACTIONS_ACCESS_KEY: ${{ secrets.ACTIONS_ACCESS_KEY }}
-  
+
   lambda-upload-zip-to-aws:
     needs: [node-run-tests]
     runs-on: ubuntu-latest
@@ -45,27 +45,27 @@ jobs:
             logging: 'off'
           },
           {
-            name: ap-south-1, 
+            name: ap-south-1,
             key: AWS-AP-SOUTH-1,
             logging: 'off'
           },
           {
-            name: ap-southeast-1,  
+            name: ap-southeast-1,
             key: AWS-AP-SOUTHEAST-1,
             logging: 'off'
           },
           {
-            name: ap-northeast-1, 
+            name: ap-northeast-1,
             key: AWS-AP-NORTHEAST-1,
             logging: 'off'
           },
           {
-            name: eu-central-1,  
+            name: eu-central-1,
             key: AWS-EU-CENTRAL-1,
             logging: 'off'
           },
           {
-            name: eu-west-3, 
+            name: eu-west-3,
             key: AWS-EU-WEST-3,
             logging: 'off'
           },
@@ -78,8 +78,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/upload-lambda
-        with: 
-          ACTIONS_ACCESS_KEY: ${{ secrets.ACTIONS_ACCESS_KEY }}
+        with:
           worker_env: >
             BASE_URL=https://rapidapi.com/testing,
             LOCATION_CONTEXT=Default,
@@ -155,4 +154,3 @@ jobs:
           file: ./docker/Dockerfile.worker
           push: true
           tags: rapidapicloud/testing-worker:latest
-  

--- a/.github/workflows/staging-change.yml
+++ b/.github/workflows/staging-change.yml
@@ -19,13 +19,12 @@ jobs:
       - run: yarn lint
       # Make zip
       - uses: ./.github/actions/build-zip
-        with: 
+        with:
           ACTIONS_ACCESS_KEY: ${{ secrets.ACTIONS_ACCESS_KEY }}
       - uses: actions/checkout@v2
       # Default worker
       - uses: ./.github/actions/upload-lambda
-        with: 
-          ACTIONS_ACCESS_KEY: ${{ secrets.ACTIONS_ACCESS_KEY }}
+        with:
           worker_env: >
             BASE_URL=https://rapidapi.xyz/testing,
             LOCATION_CONTEXT=Default,
@@ -40,8 +39,7 @@ jobs:
           function_name: rapidapi-stage-testing-worker
       # Custom worker
       - uses: ./.github/actions/upload-lambda
-        with: 
-          ACTIONS_ACCESS_KEY: ${{ secrets.ACTIONS_ACCESS_KEY }}
+        with:
           worker_env: >
             BASE_URL=https://rapidapi.xyz/testing,
             LOCATION_CONTEXT=3799087,

--- a/.github/workflows/staging-change.yml
+++ b/.github/workflows/staging-change.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - staging
+  pull_request:
+    branches:
+      - staging
+
 
 jobs:
   test-and-upload-to-staging:
@@ -20,35 +24,35 @@ jobs:
       # Make zip
       - uses: ./.github/actions/build-zip
         with:
-          ACTIONS_ACCESS_KEY: ${{ secrets.ACTIONS_ACCESS_KEY }}
-      - uses: actions/checkout@v2
-      # Default worker
-      - uses: ./.github/actions/upload-lambda
-        with:
-          worker_env: >
-            BASE_URL=https://rapidapi.xyz/testing,
-            LOCATION_CONTEXT=Default,
-            LOCATION_KEY=AWS-STAGING,
-            LOCATION_SECRET=${{ secrets.LOCATION_SECRET_STAGING_DEFAULT }},
-            WORKER_LOGGING=cli,
-            POLLING_TIME_MAX=5000,
-            FREQUENCY=1000
-          aws_access_key_id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
-          aws_region: us-east-1
-          function_name: rapidapi-stage-testing-worker
-      # Custom worker
-      - uses: ./.github/actions/upload-lambda
-        with:
-          worker_env: >
-            BASE_URL=https://rapidapi.xyz/testing,
-            LOCATION_CONTEXT=3799087,
-            LOCATION_KEY=custom-staging-worker,
-            LOCATION_SECRET=${{ secrets.LOCATION_SECRET_STAGING_CUSTOM }},
-            POLLING_TIME_MAX=70000,
-            FREQUENCY=2000,
-            WORKER_LOGGING=cli
-          aws_access_key_id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
-          aws_region: us-east-1
-          function_name: rapidapi-stage-testing-worker-custom
+          ACTIONS_ACCESS_KEY: ${{ secrets.GITHUB_TOKEN }}
+      # - uses: actions/checkout@v2
+      # # Default worker
+      # - uses: ./.github/actions/upload-lambda
+      #   with:
+      #     worker_env: >
+      #       BASE_URL=https://rapidapi.xyz/testing,
+      #       LOCATION_CONTEXT=Default,
+      #       LOCATION_KEY=AWS-STAGING,
+      #       LOCATION_SECRET=${{ secrets.LOCATION_SECRET_STAGING_DEFAULT }},
+      #       WORKER_LOGGING=cli,
+      #       POLLING_TIME_MAX=5000,
+      #       FREQUENCY=1000
+      #     aws_access_key_id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+      #     aws_secret_access_key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
+      #     aws_region: us-east-1
+      #     function_name: rapidapi-stage-testing-worker
+      # # Custom worker
+      # - uses: ./.github/actions/upload-lambda
+      #   with:
+      #     worker_env: >
+      #       BASE_URL=https://rapidapi.xyz/testing,
+      #       LOCATION_CONTEXT=3799087,
+      #       LOCATION_KEY=custom-staging-worker,
+      #       LOCATION_SECRET=${{ secrets.LOCATION_SECRET_STAGING_CUSTOM }},
+      #       POLLING_TIME_MAX=70000,
+      #       FREQUENCY=2000,
+      #       WORKER_LOGGING=cli
+      #     aws_access_key_id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+      #     aws_secret_access_key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
+      #     aws_region: us-east-1
+      #     function_name: rapidapi-stage-testing-worker-custom

--- a/.github/workflows/staging-change.yml
+++ b/.github/workflows/staging-change.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - staging
-  pull_request:
-    branches:
-      - staging
-
 
 jobs:
   test-and-upload-to-staging:
@@ -24,35 +20,35 @@ jobs:
       # Make zip
       - uses: ./.github/actions/build-zip
         with:
-          ACTIONS_ACCESS_KEY: ${{ secrets.GITHUB_TOKEN }}
-      # - uses: actions/checkout@v2
-      # # Default worker
-      # - uses: ./.github/actions/upload-lambda
-      #   with:
-      #     worker_env: >
-      #       BASE_URL=https://rapidapi.xyz/testing,
-      #       LOCATION_CONTEXT=Default,
-      #       LOCATION_KEY=AWS-STAGING,
-      #       LOCATION_SECRET=${{ secrets.LOCATION_SECRET_STAGING_DEFAULT }},
-      #       WORKER_LOGGING=cli,
-      #       POLLING_TIME_MAX=5000,
-      #       FREQUENCY=1000
-      #     aws_access_key_id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
-      #     aws_secret_access_key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
-      #     aws_region: us-east-1
-      #     function_name: rapidapi-stage-testing-worker
-      # # Custom worker
-      # - uses: ./.github/actions/upload-lambda
-      #   with:
-      #     worker_env: >
-      #       BASE_URL=https://rapidapi.xyz/testing,
-      #       LOCATION_CONTEXT=3799087,
-      #       LOCATION_KEY=custom-staging-worker,
-      #       LOCATION_SECRET=${{ secrets.LOCATION_SECRET_STAGING_CUSTOM }},
-      #       POLLING_TIME_MAX=70000,
-      #       FREQUENCY=2000,
-      #       WORKER_LOGGING=cli
-      #     aws_access_key_id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
-      #     aws_secret_access_key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
-      #     aws_region: us-east-1
-      #     function_name: rapidapi-stage-testing-worker-custom
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+      # Default worker
+      - uses: ./.github/actions/upload-lambda
+        with:
+          worker_env: >
+            BASE_URL=https://rapidapi.xyz/testing,
+            LOCATION_CONTEXT=Default,
+            LOCATION_KEY=AWS-STAGING,
+            LOCATION_SECRET=${{ secrets.LOCATION_SECRET_STAGING_DEFAULT }},
+            WORKER_LOGGING=cli,
+            POLLING_TIME_MAX=5000,
+            FREQUENCY=1000
+          aws_access_key_id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
+          aws_region: us-east-1
+          function_name: rapidapi-stage-testing-worker
+      # Custom worker
+      - uses: ./.github/actions/upload-lambda
+        with:
+          worker_env: >
+            BASE_URL=https://rapidapi.xyz/testing,
+            LOCATION_CONTEXT=3799087,
+            LOCATION_KEY=custom-staging-worker,
+            LOCATION_SECRET=${{ secrets.LOCATION_SECRET_STAGING_CUSTOM }},
+            POLLING_TIME_MAX=70000,
+            FREQUENCY=2000,
+            WORKER_LOGGING=cli
+          aws_access_key_id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
+          aws_region: us-east-1
+          function_name: rapidapi-stage-testing-worker-custom


### PR DESCRIPTION
Remove references to `ACTIONS_ACCESS_KEY`

Build zip works with `GITHUB_TOKEN` here: https://github.com/RapidAPI/testing-worker/actions/runs/4501125850/jobs/7921136912?pr=57